### PR TITLE
Increase CPU resources and replicas for backend-service

### DIFF
--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -5,27 +5,27 @@ metadata:
   labels:
     app: backend-service
 spec:
-  replicas: 1
+  replicas: "3"
   selector:
     matchLabels:
       app: backend-service
   template:
     spec:
       containers:
-      - name: backend-service
-        image: me-west1-docker.pkg.dev/koala-ops-demo-373407/koala-repo/backend-service:latest
-        resources:
-          requests:
-            cpu: 100m
-            memory: 200Mi
-          limits:
-            cpu: 500m
-            memory: 500Mi
-        ports:
-        - containerPort: 8080
-        envFrom:
-        - configMapRef:
-            name: backend-service-configmap
+        - name: backend-service
+          image: me-west1-docker.pkg.dev/koala-ops-demo-373407/koala-repo/backend-service:latest
+          resources:
+            requests:
+              cpu: 150m
+              memory: 200Mi
+            limits:
+              cpu: 750m
+              memory: 500Mi
+          ports:
+            - containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: backend-service-configmap
     metadata:
       labels:
         app: backend-service


### PR DESCRIPTION
This pull request increases the CPU requests and limits by 50% and scales the number of replicas to 3 for the backend-service deployment. These changes aim to address the high CPU utilization issue and distribute the load more effectively.