### PR TITLE
Increase CPU resources by 30% for backend-service

### DIFF
--- a/deploy/overlays/autopush/backend-service-cpu-patch.yaml
+++ b/deploy/overlays/autopush/backend-service-cpu-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/cpu
+  value: "130m"
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/cpu
+  value: "650m"

--- a/deploy/overlays/dev/backend-service-cpu-patch.yaml
+++ b/deploy/overlays/dev/backend-service-cpu-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/cpu
+  value: "130m"
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/cpu
+  value: "650m"

--- a/deploy/overlays/prod/backend-service-cpu-patch.yaml
+++ b/deploy/overlays/prod/backend-service-cpu-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/cpu
+  value: "130m"
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/cpu
+  value: "650m"

--- a/deploy/overlays/staging/backend-service-cpu-patch.yaml
+++ b/deploy/overlays/staging/backend-service-cpu-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/template/spec/containers/0/resources/requests/cpu
+  value: "130m"
+- op: replace
+  path: /spec/template/spec/containers/0/resources/limits/cpu
+  value: "650m"


### PR DESCRIPTION
This pull request increases the CPU requests and limits for the backend-service deployment by 30% to address high CPU utilization issues. The new values are:
- CPU Requests: 130m
- CPU Limits: 650m